### PR TITLE
[Impl] TCP Trace Simulator

### DIFF
--- a/redart/simulator/dart_sim.py
+++ b/redart/simulator/dart_sim.py
@@ -393,13 +393,13 @@ class PacketTracker(TrackerTrait[PacketKeyT, PacketValueT]):
                 elif self.time_scale == TimestampScale.MICROSECOND:
                     self.rtt_samples[record_key].append(
                         rtt / datetime.timedelta(microseconds=1))
-                upper = 500 if self.time_scale == TimestampScale.MICROSECOND else 0.5 if self.time_scale == TimestampScale.MILLISECOND else 0.0005
-                if self.rtt_samples[record_key][-1] < upper:
-                    # ignore "short legs" (i.e. RTT measured between the host and Wireshark)
-                    self.logger.warning(
-                        "Dropping short leg: %s -> %s @ %s", packet.src, packet.dst, packet.index)
-                    self.rtt_samples[record_key].pop()
-                    pass
+                # upper = 500 if self.time_scale == TimestampScale.MICROSECOND else 0.5 if self.time_scale == TimestampScale.MILLISECOND else 0.0005
+                # if self.rtt_samples[record_key][-1] < upper:
+                #     # ignore "short legs" (i.e. RTT measured between the host and Wireshark)
+                #     self.logger.warning(
+                #         "Dropping short leg: %s -> %s @ %s", packet.src, packet.dst, packet.index)
+                #     self.rtt_samples[record_key].pop()
+                #     pass
 
     def update(self, packet: Packet, packet_value: PacketValueT):
         self.logger.info("Update SEQ packet: %s -> %s @ %s",

--- a/redart/simulator/naive_sim.py
+++ b/redart/simulator/naive_sim.py
@@ -19,10 +19,10 @@ class NaiveSimulator(SimulatorTrait):
         key = packet.to_src_dst_key()
         if packet.is_fin():
             # flow finished, clear the peer from record
-            self.record = dict(
-                filter(lambda x: x[0][0] != key, self.record.items()))
-            self.seen = set(filter(lambda x: not isinstance(
-                x, tuple) or x[0] != key, self.seen))
+            # self.record = dict(
+            #     filter(lambda x: x[0][0] != key, self.record.items()))
+            # self.seen = set(filter(lambda x: not isinstance(
+            #     x, tuple) or x[0] != key, self.seen))
             return
         if packet.is_syn():
             return
@@ -32,10 +32,6 @@ class NaiveSimulator(SimulatorTrait):
                 self.record[key, eack] = packet
                 self.seen.add((key, eack))
         elif packet.is_ack():
-            if packet.ack not in self.seen:
-                self.seen.add(packet.ack)
-            else:
-                return
             if (key, packet.ack) in self.record:
                 if key not in self.rtt_samples:
                     self.rtt_samples[key] = []

--- a/redart/simulator/tcp_trace_sim.py
+++ b/redart/simulator/tcp_trace_sim.py
@@ -1,0 +1,71 @@
+from redart.simulator import SimulatorTrait
+from redart.data import Packet
+
+
+class TCPTraceSim(SimulatorTrait):
+    def __init__(self, *, name=None):
+        self.flow_key_to_names = {}
+        self.rtt_samples = {}
+        super().__init__({}, {}, name=name)
+
+    def insert_pt(self, packet: Packet, eack: int):
+        self.packet_tracker[packet.to_src_dst_key(), eack] = packet
+
+    def warning(self, msg: str, packet: Packet):
+        self.logger.warning("%s. %s:%s -> %s:%s @ %s",
+                            msg, packet.src, packet.srcport, packet.dst, packet.dstport, packet.index)
+
+    def process_SEQ(self, packet: Packet):
+        assert packet.is_seq()
+        flow_key = packet.to_src_dst_key()
+        eack = packet.seq + packet.packet_size
+        if flow_key in self.range_tracker and not self.range_tracker[flow_key][0] == self.range_tracker[flow_key][1]:
+            highest_ack, highest_eack = self.range_tracker[flow_key]
+            if packet.seq >= highest_eack:
+                if packet.seq == highest_eack:
+                    self.range_tracker[flow_key] = (highest_ack, eack)
+                else:
+                    self.range_tracker[flow_key] = (packet.seq, eack)
+                self.insert_pt(packet, eack)
+            else:
+                self.range_tracker[flow_key] = (eack, eack)
+        else:
+            self.range_tracker[flow_key] = (packet.seq, eack)
+            self.insert_pt(packet, eack)
+        
+    def process_ACK(self, packet: Packet):
+        assert packet.is_ack()
+        flow_key = packet.to_src_dst_key()
+        if flow_key not in self.range_tracker or self.range_tracker[flow_key][0] == self.range_tracker[flow_key][1]:
+            self.range_tracker[flow_key] = (packet.ack, packet.ack)
+            return
+        ack = packet.ack
+        if flow_key in self.range_tracker:
+            highest_ack, highest_eack = self.range_tracker[flow_key]
+            if ack < highest_ack or ack > highest_eack:
+                self.warning("Dropping out-of-range ACK", packet)
+            elif ack == highest_ack:
+                self.warning("Retransmission indicated by duplicated ACK", packet)
+                self.range_tracker[flow_key] = (highest_eack, highest_eack)
+                if (flow_key, highest_eack) in self.packet_tracker:
+                    self.packet_tracker.pop((flow_key, highest_eack))
+            elif highest_ack < ack <= highest_eack:
+                self.range_tracker[flow_key] = (ack, highest_eack)
+                if (flow_key, ack) in self.packet_tracker:
+                    packet_record = self.packet_tracker.pop((flow_key, ack))
+                    if flow_key not in self.flow_key_to_names:
+                        self.flow_key_to_names[flow_key] = (packet_record.src, packet_record.srcport,
+                                                             packet_record.dst, packet_record.dstport)
+                    if flow_key not in self.rtt_samples:
+                        self.rtt_samples[flow_key] = []
+                    self.rtt_samples[flow_key].append(packet.time_since(packet_record))
+        else:
+            self.warning("Flow not found in packet tracker", packet)
+
+    def process_packet(self, packet: Packet):
+        if packet.is_fin() or packet.is_syn():
+            return
+        if packet.is_seq():
+            self.process_SEQ(packet)
+        elif packet.is_ack():
+            self.process_ACK(packet)

--- a/tests/plot.py
+++ b/tests/plot.py
@@ -8,7 +8,7 @@ import run_ground_truth
 import test_dart_trackers
 
 import redart
-from redart.simulator import dart_sim
+from redart.simulator import dart_sim, tcp_trace_sim
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dataset", type=str, default="test")
@@ -29,7 +29,8 @@ f = "../data/{}.pcap".format(dataset)
 redart.init(redart.config.TimestampScale.MICROSECOND, ignore_syn=True)
 
 print("===================== TRUTH =====================")
-truth = run_ground_truth.main(f, cache_file=f+".cache")
+truth = run_ground_truth.main(
+    f, cache_file=f+".cache", constr=tcp_trace_sim.TCPTraceSim)
 truth_values = {}
 
 for pkt in truth[0]:

--- a/tests/run_ground_truth.py
+++ b/tests/run_ground_truth.py
@@ -8,9 +8,9 @@ redart.init(redart.config.TimestampScale.MICROSECOND)
 logging = get_logger("RunNaiveSim")
 
 
-def main(file: str, trace=None, cache_file: str = None):
+def main(file: str, trace=None, cache_file: str = None, constr=NaiveSimulator):
     logging.info("Running ground truth simulator on %s", file)
-    simulator = NaiveSimulator()
+    simulator = constr()
     if trace is None:
         trace = parse_pcap(file, cache_file)
     simulator.run_trace(trace)

--- a/tests/test_dart_trackers.py
+++ b/tests/test_dart_trackers.py
@@ -11,9 +11,6 @@ from redart.simulator.dart_sim import (
     RangeTracker)
 
 INF = 66145576821500209494471478855081
-redart.init(redart.config.TimestampScale.MILLISECOND,
-            ignore_syn=False,
-            logging_level="DEBUG")
 
 
 def test_tracker_operations():
@@ -113,5 +110,8 @@ def test_limited_memory(file: str, trace: list[Packet] = None, cache_file: str =
 
 if __name__ == '__main__':
     # test_tracker_operations()c
+    redart.init(redart.config.TimestampScale.MILLISECOND,
+                ignore_syn=False,
+                logging_level="DEBUG")
     test_limited_memory("../data/test.pcap",
                         cache_file="../data/test.pcap.cache")


### PR DESCRIPTION
This PR implements a TCP trace simulator (following baseline implementation from [DART repo](https://github.com/SatadalSengupta/sigcomm22-paper67-artifacts/blob/021dd30cc03ec22a94a06ae98a2df479a9177b95/simulations/TCPTraceConst.py))